### PR TITLE
Add another test case TestOperatorPrecedenceParsing

### DIFF
--- a/src/monkey/parser/parser_test.go
+++ b/src/monkey/parser/parser_test.go
@@ -308,6 +308,10 @@ func TestOperatorPrecendenceParsing(t *testing.T) {
 			"((-a) * b)",
 		},
 		{
+			"-3 - -5",
+			"((-3) - (-5))",
+		},
+		{
 			"!-a",
 			"(!(-a))",
 		},


### PR DESCRIPTION
This test covers a prefix operator after an infix operator.
