### PR TITLE
feat(lexer): generate tokens in a separate thread

### DIFF
--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -12,16 +12,25 @@ func TestNewLexer(t *testing.T) {
 		input string
 		lexer Lexer
 	}{
-		{"", Lexer{"", 0, 1, 0}},
-		{" ", Lexer{" ", 0, 1, ' '}},
-		{"a", Lexer{"a", 0, 1, 'a'}},
-		{"ab", Lexer{"ab", 0, 1, 'a'}},
+		{"", Lexer{"", 0, 1, 0, nil}},
+		{" ", Lexer{" ", 0, 1, ' ', nil}},
+		{"a", Lexer{"a", 0, 1, 'a', nil}},
+		{"ab", Lexer{"ab", 0, 1, 'a', nil}},
 	}
 
 	for i, test := range tests {
 		l := *New(test.input)
-		if test.lexer != l {
-			t.Errorf("tests[%d] failed, expected=%+v, got=%+v\n", i, test.lexer, l)
+		if test.lexer.input != l.input {
+			t.Errorf("tests[%d] failed, expected input=%s, got=%s\n", i, test.lexer.input, l.input)
+		}
+		if test.lexer.position != l.position {
+			t.Errorf("tests[%d] failed, expected position=%d, got=%d\n", i, test.lexer.position, l.position)
+		}
+		if test.lexer.readPosition != l.readPosition {
+			t.Errorf("tests[%d] failed, expected input=%d, got=%d\n", i, test.lexer.readPosition, l.readPosition)
+		}
+		if test.lexer.ch != l.ch {
+			t.Errorf("tests[%d] failed, expected input=%c, got=%c\n", i, test.lexer.ch, l.ch)
 		}
 	}
 }

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -333,6 +333,7 @@ func (p *Parser) parsePrefixExpression() ast.Expression {
 }
 
 func (p *Parser) parseGroupedExpression() ast.Expression {
+	// defer untrace(trace("parseGroupedExpression"))
 	p.nextToken()
 
 	exp := p.parseExpression(LOWEST)
@@ -345,6 +346,7 @@ func (p *Parser) parseGroupedExpression() ast.Expression {
 }
 
 func (p *Parser) parseIfExpression() ast.Expression {
+	// defer untrace(trace("parseIfExpression"))
 	expression := &ast.IfExpression{Token: p.curToken}
 
 	if !p.expectPeek(token.LPAREN) {
@@ -379,6 +381,7 @@ func (p *Parser) parseIfExpression() ast.Expression {
 }
 
 func (p *Parser) parseBlockStatement() *ast.BlockStatement {
+	// defer untrace(trace("parseBlockStatement"))
 	block := &ast.BlockStatement{Token: p.curToken}
 	block.Statements = []ast.Statement{}
 
@@ -396,6 +399,7 @@ func (p *Parser) parseBlockStatement() *ast.BlockStatement {
 }
 
 func (p *Parser) parseFunctionParameters() []*ast.Identifier {
+	// defer untrace(trace("parseFunctionParameters"))
 	identifiers := []*ast.Identifier{}
 
 	if p.peekTokenIs(token.RPAREN) {
@@ -423,6 +427,7 @@ func (p *Parser) parseFunctionParameters() []*ast.Identifier {
 }
 
 func (p *Parser) parseFunctionLiteral() ast.Expression {
+	// defer untrace(trace("parseFunctionLiteral"))
 	lit := &ast.FunctionLiteral{Token: p.curToken}
 
 	if !p.expectPeek(token.LPAREN) {
@@ -441,12 +446,14 @@ func (p *Parser) parseFunctionLiteral() ast.Expression {
 }
 
 func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
+	// defer untrace(trace("parseCallExpression"))
 	exp := &ast.CallExpression{Token: p.curToken, Function: function}
 	exp.Arguments = p.parseCallArguments()
 	return exp
 }
 
 func (p *Parser) parseCallArguments() []ast.Expression {
+	// defer untrace(trace("parseCallArguments"))
 	args := []ast.Expression{}
 
 	if p.peekTokenIs(token.RPAREN) {


### PR DESCRIPTION
As a first step towards parallelizing the interpreter, the generation of
tokens by the lexer happens in a buffered channel.  Token requests from
the Parser return values from the new channel.
