### PR TITLE
cleanup: fix spelling of TestIfEseExpressions

### DIFF
--- a/pkg/evaluator/evaluator_test.go
+++ b/pkg/evaluator/evaluator_test.go
@@ -89,7 +89,7 @@ func TestReturnStatement(t *testing.T) {
 	}
 }
 
-func TestIfEseExpressions(t *testing.T) {
+func TestIfElseExpressions(t *testing.T) {
 	tests := []struct {
 		input    string
 		expected interface{}


### PR DESCRIPTION
Should be `TestIfElseExpressions`
