### PR TITLE
chore(formatting): add single space between functions

### DIFF
--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -292,6 +292,7 @@ func evalMinusPrefixOperatorExpression(right object.Object) object.Object {
 	value := right.(*object.Integer).Value
 	return &object.Integer{Value: -value}
 }
+
 func evalExpressions(exps []ast.Expression, env *object.Environment) []object.Object {
 	var result []object.Object
 


### PR DESCRIPTION
Adds a blank link separation between `evalMinusPrefixOperatorExpression`
and `evalExpressions`.
