### PR TITLE
feat(strings): add support for string literals

### DIFF
--- a/pkg/ast/ast.go
+++ b/pkg/ast/ast.go
@@ -262,3 +262,12 @@ func (ce *CallExpression) String() string {
 
 	return out.String()
 }
+
+type StringLiteral struct {
+	Token token.Token
+	Value string
+}
+
+func (sl *StringLiteral) expressionNode()      {}
+func (sl *StringLiteral) TokenLiteral() string { return sl.Token.Literal }
+func (sl *StringLiteral) String() string       { return sl.Token.Literal }

--- a/pkg/evaluator/evaluator.go
+++ b/pkg/evaluator/evaluator.go
@@ -44,6 +44,9 @@ func Eval(node ast.Node, env *object.Environment) object.Object {
 	case *ast.IntegerLiteral:
 		return &object.Integer{Value: node.Value}
 
+	case *ast.StringLiteral:
+		return &object.String{Value: node.Value}
+
 	case *ast.LetStatement:
 		val := Eval(node.Value, env)
 		if isError(val) {

--- a/pkg/lexer/lexer.go
+++ b/pkg/lexer/lexer.go
@@ -79,6 +79,16 @@ func (l *Lexer) readIdentifier() string {
 	return l.input[position:l.position]
 }
 
+// Returns the sequence of characters up to the next ".
+func (l *Lexer) readString() string {
+	position := l.position
+	for l.ch != '"' && l.ch != 0 {
+		l.readChar()
+	}
+
+	return l.input[position:l.position]
+}
+
 // Checks if ch is an integer character returning true if ch meets the criteria.
 // False otherwise.
 func isDigit(ch byte) bool {
@@ -153,6 +163,15 @@ func (l *Lexer) nextToken() token.Token {
 		tok = newToken(token.LT, l.ch)
 	case '>':
 		tok = newToken(token.GT, l.ch)
+	case '"':
+		l.readChar()
+		literal := l.readString()
+		if l.ch == '"' {
+			l.readChar()
+			tok = token.Token{Type: token.STRING, Literal: literal}
+		} else {
+			tok = newToken(token.ILLEGAL, l.ch)
+		}
 	case 0:
 		tok = newEofToken()
 	default:

--- a/pkg/lexer/lexer_test.go
+++ b/pkg/lexer/lexer_test.go
@@ -96,6 +96,9 @@ func TestNextToken(t *testing.T) {
 	if result == 15 {
 		return result;
 	}
+
+	"foobar"
+	"foo bar"
 	`
 
 	tests := []struct {
@@ -171,6 +174,8 @@ func TestNextToken(t *testing.T) {
 		{token.IDENT, "result"},
 		{token.SEMICOLON, ";"},
 		{token.RBRACE, "}"},
+		{token.STRING, "foobar"},
+		{token.STRING, "foo bar"},
 		{token.EOF, "EOF"},
 	}
 

--- a/pkg/object/object.go
+++ b/pkg/object/object.go
@@ -23,6 +23,7 @@ const (
 	INTEGER_OBJ      = "INTEGER"
 	RETURN_VALUE_OBJ = "RETURN_VALUE"
 	FUNCTION_OBJ     = "FUNCTION"
+	STRING_OBJ       = "STRING"
 )
 
 // Errors
@@ -54,6 +55,14 @@ type Integer struct {
 
 func (i *Integer) Inspect() string  { return fmt.Sprintf("%d", i.Value) }
 func (i *Integer) Type() ObjectType { return INTEGER_OBJ }
+
+// Strings
+type String struct {
+	Value string
+}
+
+func (s *String) Inspect() string  { return s.Value }
+func (s *String) Type() ObjectType { return STRING_OBJ }
 
 // Returns
 type ReturnValue struct {

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -81,6 +81,7 @@ func New(l *lexer.Lexer) *Parser {
 	p.prefixParseFns = make(map[token.TokenType]prefixParseFn)
 	p.registerPrefix(token.IDENT, p.parseIdentifier)
 	p.registerPrefix(token.INT, p.parseIntegerLiteral)
+	p.registerPrefix(token.STRING, p.parseStringLiteral)
 	p.registerPrefix(token.BANG, p.parsePrefixExpression)
 	p.registerPrefix(token.MINUS, p.parsePrefixExpression)
 	p.registerPrefix(token.TRUE, p.parseBoolean)
@@ -302,6 +303,11 @@ func (p *Parser) parseIntegerLiteral() ast.Expression {
 
 	literal.Value = value
 	return literal
+}
+
+func (p *Parser) parseStringLiteral() ast.Expression {
+	// defer untrace(trace("parseIdentifier"))
+	return &ast.StringLiteral{Token: p.curToken, Value: p.curToken.Literal}
 }
 
 func (p *Parser) parseInfixExpression(left ast.Expression) ast.Expression {

--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -212,6 +212,25 @@ func TestReturnStatements(t *testing.T) {
 	}
 }
 
+func TestStringLiteralExpression(t *testing.T) {
+	input := `"hello world";`
+
+	l := lexer.New(input)
+	p := New(l)
+	program := p.ParseProgram()
+	checkParserErrors(t, p)
+
+	stmt := program.Statements[0].(*ast.ExpressionStatement)
+	literal, ok := stmt.Expression.(*ast.StringLiteral)
+	if !ok {
+		t.Fatalf("exp not *ast.StringLiteral. got=%T", stmt.Expression)
+	}
+
+	if literal.Value != "hello world" {
+		t.Errorf("literal.Value not %q. got=%q", "hello world", literal.Value)
+	}
+}
+
 func TestIdentifierExpression(t *testing.T) {
 	input := "foobar;"
 

--- a/pkg/token/token.go
+++ b/pkg/token/token.go
@@ -31,8 +31,9 @@ const (
 	ILLEGAL = "ILLEGAL"
 	EOF     = "EOF"
 
-	IDENT = "IDENT"
-	INT   = "INT"
+	IDENT  = "IDENT"
+	INT    = "INT"
+	STRING = "STRING"
 
 	// Delimiters
 	COMMA     = ","


### PR DESCRIPTION
The initial string literal support allows for creating and reading
strings.  Additional support such as string concatenation will be built
on top of the core data type.
