### PR TITLE
refactor(cleanup): make parseExpressionList generic for reuse

### DIFF
--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -489,34 +489,8 @@ func (p *Parser) parseExpressionList(end token.TokenType) []ast.Expression {
 func (p *Parser) parseCallExpression(function ast.Expression) ast.Expression {
 	// defer untrace(trace("parseCallExpression"))
 	exp := &ast.CallExpression{Token: p.curToken, Function: function}
-	exp.Arguments = p.parseCallArguments()
+	exp.Arguments = p.parseExpressionList(token.RPAREN)
 	return exp
-}
-
-func (p *Parser) parseCallArguments() []ast.Expression {
-	// defer untrace(trace("parseCallArguments"))
-	args := []ast.Expression{}
-
-	if p.peekTokenIs(token.RPAREN) {
-		p.nextToken()
-		return args
-	}
-
-	p.nextToken()
-	args = append(args, p.parseExpression(LOWEST))
-
-	for p.peekTokenIs(token.COMMA) {
-		p.nextToken()
-		p.nextToken()
-		args = append(args, p.parseExpression(LOWEST))
-
-	}
-
-	if !p.expectPeek(token.RPAREN) {
-		return nil
-	}
-
-	return args
 }
 
 func (p *Parser) parseIndexExpression(left ast.Expression) ast.Expression {


### PR DESCRIPTION
parseCallExpression and parseArrayLiteral now share parseExpressionList
since they follow the same pattern.
