### PR TITLE
feat(builtin): add rest builtin for arrays

### DIFF
--- a/pkg/evaluator/builtins.go
+++ b/pkg/evaluator/builtins.go
@@ -57,4 +57,25 @@ var builtins = map[string]*object.Builtin{
 			return NULL
 		},
 	},
+	"rest": {
+		Fn: func(args ...object.Object) object.Object {
+			if len(args) != 1 {
+				return newError("wrong number of arguments. got=%d, want=%d", len(args), 1)
+			}
+
+			if args[0].Type() != object.ARRAY_OBJ {
+				return newError("argument to `rest` must be ARRAY, got %s", args[0].Type())
+			}
+
+			arr := args[0].(*object.Array)
+			length := len(arr.Elements)
+			if length > 0 {
+				newElements := make([]object.Object, length-1, length-1)
+				copy(newElements, arr.Elements[1:length])
+				return &object.Array{Elements: newElements}
+			}
+
+			return NULL
+		},
+	},
 }


### PR DESCRIPTION
The `rest` builtin returns all elements excluding the first one in a new
array.
