### PR TITLE
feat(builtin): add puts builtin for printing

### DIFF
--- a/pkg/evaluator/builtins.go
+++ b/pkg/evaluator/builtins.go
@@ -1,7 +1,11 @@
 // monkey language builtin functions
 package evaluator
 
-import "github.com/freddiehaddad/monkey.interpreter/pkg/object"
+import (
+	"fmt"
+
+	"github.com/freddiehaddad/monkey.interpreter/pkg/object"
+)
 
 var builtins = map[string]*object.Builtin{
 	"len": {
@@ -95,6 +99,14 @@ var builtins = map[string]*object.Builtin{
 			copy(newElements, arr.Elements)
 			newElements[length] = args[1]
 			return &object.Array{Elements: newElements}
+		},
+	},
+	"puts": {
+		Fn: func(args ...object.Object) object.Object {
+			for _, arg := range args {
+				fmt.Println(arg.Inspect())
+			}
+			return NULL
 		},
 	},
 }


### PR DESCRIPTION
The puts builtin uses the Println function the fmt package of Go to
print a variable number arguments, each on a new line.
